### PR TITLE
New Jinja defaults, document how to restore them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ pip-wheel-metadata
 .mypy_cache/*
 .cache
 *.log
+
+# Editors
+.vscode

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A slightly customized Jinja2 templating is used. The main difference is
 those variables are referenced with `[[ name ]]` instead of
 `{{ name }}` and blocks are `[% if name %]` instead of
 `{% if name %}`. To read more about templating see the [Jinja2
-documentation](http://jinja.pocoo.org/docs>).
+documentation](https://jinja.palletsprojects.com/).
 
 If a **YAML** file named `copier.yml` is found in the root of the
 project (alternatively, a YAML file named `copier.yaml`), the user will be
@@ -204,6 +204,36 @@ Uses the template in _src_path_ to generate a new project at _dst_path_.
 
 - **envops** (dict):<br>
   Extra options for the Jinja template environment.
+  See available options in
+  [Jinja's docs](https://jinja.palletsprojects.com/en/2.10.x/api/#jinja2.Environment).
+
+  Copier uses these defaults that are different from Jinja's:
+
+  ```yml
+  # copier.yml
+  _envops:
+    block_start_string: "[%"
+    block_end_string: "%]"
+    comment_start_string: "[#"
+    comment_end_string: "#]"
+    variable_start_string: "[["
+    variable_end_string: "]]"
+    keep_trailing_newline: true
+  ```
+
+  You can use default Jinja syntax with:
+
+  ```yml
+  # copier.yml
+  _envops:
+    block_start_string: "{%"
+    block_end_string: "%}"
+    comment_start_string: "{#"
+    comment_end_string: "#}"
+    variable_start_string: "{{"
+    variable_end_string: "}}"
+    keep_trailing_newline: false
+  ```
 
 - **extra_paths** (list):<br>
   Additional paths, from where to search for templates. This is intended to be

--- a/copier/config/objects.py
+++ b/copier/config/objects.py
@@ -49,6 +49,8 @@ class EnvOps(BaseModel):
     autoescape: StrictBool = False
     block_start_string: str = "[%"
     block_end_string: str = "%]"
+    comment_start_string: str = "[#"
+    comment_end_string: str = "#]"
     variable_start_string: str = "[["
     variable_end_string: str = "]]"
     keep_trailing_newline: StrictBool = True

--- a/tests/demo_normal_jinja2/TODO.txt.tmpl
+++ b/tests/demo_normal_jinja2/TODO.txt.tmpl
@@ -1,0 +1,6 @@
+[[ {{ name }} TODO LIST]]
+{# Let's put an ugly not-comment below #}
+[# GROG #]
+    {% if name == 'Guybrush' %}
+    - {{ todo }}
+    {% endif %}

--- a/tests/demo_normal_jinja2/copier.yml
+++ b/tests/demo_normal_jinja2/copier.yml
@@ -1,0 +1,12 @@
+_envops:
+  variable_start_string: "{{"
+  variable_end_string: "}}"
+  block_start_string: "{%"
+  block_end_string: "%}"
+  comment_start_string: "{#"
+  comment_end_string: "#}"
+  lstrip_blocks: true
+  trim_blocks: true
+
+name: Guybrush
+todo: Become a pirate

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,6 +36,8 @@ GOOD_ENV_OPS = {
     "variable_end_string": ">>",
     "keep_trailing_newline": False,
     "i_am_not_a_member": None,
+    'comment_end_string': '#>',
+    'comment_start_string': '<#',
 }
 
 

--- a/tests/test_normal_jinja2.py
+++ b/tests/test_normal_jinja2.py
@@ -1,0 +1,10 @@
+import copier
+
+from .helpers import PROJECT_TEMPLATE
+
+
+def test_normal_jinja2(dst):
+    copier.copy(f"{PROJECT_TEMPLATE}_normal_jinja2", dst, force=True)
+    todo = (dst / "TODO.txt").read_text()
+    expected = '[[ Guybrush TODO LIST]]\n[# GROG #]\n    - Become a pirate\n'
+    assert todo == expected


### PR DESCRIPTION
- Alter comments syntax to match project templating syntax: `[# This is a comment now #]`.
- Document and test the way to restore Jinja2 default syntax. This is not obvious otherwise.
- Update Jinja docs location.

@Tecnativa TT20357