### PR TITLE
Add .copier-answers.yml to remember last answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ function.
 Since version 3.0, only Python 3.6 or later are supported. Please use the
 2.5.1 version if your project runs on a previous Python version.
 
-## The copier.yml file
+## The `copier.yml`ile
 
-If a `copier.yml`, or `copier.yaml` file is found in the root of the project,
+If a `copier.yml`, or `copier.yaml` file is found in the root of the template,
 it will be read and used for two purposes:
 
 ### Prompt the user for information
@@ -135,6 +135,50 @@ _extra_paths:
 
 **Warning:** Use only trusted project templates as these tasks run with the
 same level of access as your user.
+
+## The `.copier-answers.yml` file
+
+If the destination path exists and a `.copier-answers.yml` (or `.copier-answers.yaml`) file is
+present there, it will be used to load last user's answers to the questions
+made in [the `copier.yml` file](#the-copieryml-file).
+
+This makes projects easier to update because when the user is asked, the default
+answers will be the last ones he used.
+
+To make sure projects based on your templates can make use of this nice feature,
+add a file called `.copier-answers.yml.tmpl` in your template's root folder, with
+this content:
+
+```yml
+# Changes here will be overwritten by Copier
+[[ _log|to_nice_yaml ]]
+```
+
+The builtin `_log` variable includes all data needed to smooth future updates
+of this project. This includes (but is not limited to) all JSON-serializable
+values declared as user questions in [the `copier.yml` file](#the-copieryml-file).
+
+As you can see, you also have the power to customize what will be logged here.
+Keys that start with an underscore (`_`) are specific to Copier. Other keys
+should match questions in `copier.yml`.
+
+## Template helpers
+
+In addition to [all the features Jinja supports](https://jinja.palletsprojects.com/en/2.10.x/templates/),
+Copier includes:
+
+### Builtin variables/functions
+
+- `now()` to get current UTC time.
+- `make_secret()` to get a random string.
+
+### Builtin filters
+
+- `anything|to_nice_yaml` to print as pretty-formatted YAML.
+
+  Without arguments it defaults to:
+  `anything|to_nice_yaml(indent=2, width=80, allow_unicode=True)`,
+  but you can modify those.
 
 ---
 

--- a/copier/config/factory.py
+++ b/copier/config/factory.py
@@ -1,8 +1,8 @@
-from typing import Tuple
+from typing import Any, Tuple
 
 from ..types import AnyByStrDict, OptAnyByStrDict, OptBool, OptStrSeq
 from .objects import DEFAULT_DATA, ConfigData, EnvOps, Flags
-from .user_data import load_config_data, query_user_data
+from .user_data import load_config_data, load_logfile_data, query_user_data
 
 __all__ = ("make_config",)
 
@@ -45,7 +45,12 @@ def make_config(
     args = {k: v for k, v in locals().items() if v is not None}
 
     file_data = load_config_data(src_path, quiet=True)
+    answers_data = load_logfile_data(dst_path, quiet=True)
     config_data, query_data = filter_config(file_data)
+    query_data.update(filter(
+        lambda item: item[0] in query_data,
+        answers_data.items(),
+    ))
 
     if not force:
         query_data = query_user_data(query_data)

--- a/copier/types.py
+++ b/copier/types.py
@@ -20,3 +20,4 @@ OptAnyByStrDict = Optional[AnyByStrDict]
 # miscellaneous
 CheckPathFunc = Callable[[StrOrPath], bool]
 T = TypeVar("T")
+JSONSerializable = (dict, list, str, int, float, bool, type(None))

--- a/tests/demo_logfile/.copier-answers.yml.tmpl
+++ b/tests/demo_logfile/.copier-answers.yml.tmpl
@@ -1,0 +1,2 @@
+# Changes here will be overwritten by Copier
+[[ _log|to_nice_yaml ]]

--- a/tests/demo_logfile/copier.yml
+++ b/tests/demo_logfile/copier.yml
@@ -1,0 +1,1 @@
+round: 1st

--- a/tests/demo_logfile/round.txt.tmpl
+++ b/tests/demo_logfile/round.txt.tmpl
@@ -1,0 +1,1 @@
+It's the [[round]] round.

--- a/tests/test_logfile.py
+++ b/tests/test_logfile.py
@@ -1,0 +1,28 @@
+import copier
+from copier.config.user_data import load_logfile_data
+from .helpers import PROJECT_TEMPLATE
+
+SRC = f"{PROJECT_TEMPLATE}_logfile"
+
+
+def test_logfile(dst):
+    """Test copier behaves properly when using a logfile."""
+    round_file = dst / "round.txt"
+
+    # Check 1st round is properly executed and remembered
+    copier.copy(SRC, dst, force=True)
+    assert round_file.read_text() == "It's the 1st round.\n"
+    log = load_logfile_data(dst)
+    assert log["round"] == "1st"
+
+    # Check 2nd round is properly executed and remembered
+    copier.copy(SRC, dst, {"round": "2nd"}, force=True)
+    assert round_file.read_text() == "It's the 2nd round.\n"
+    log = load_logfile_data(dst)
+    assert log["round"] == "2nd"
+
+    # Check repeating 2nd is properly executed and remembered
+    copier.copy(SRC, dst, force=True)
+    assert round_file.read_text() == "It's the 2nd round.\n"
+    log = load_logfile_data(dst)
+    assert log["round"] == "2nd"


### PR DESCRIPTION
- If the copy destination exists and has a `.copierlog.yml`, all questions asked in the template `copier.yml` file will get the answer found in `.copierlog.yml` by default.
- For now, there are no `_private` variables in the copierlog, but in the future there might be, so I'm documenting that now.
- Add docs for some of Copier's hidden features.
- Add `to_nice_yaml` filter, to be able to dump beautiful YAML. [This name matches that on Ansible](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#filters-for-formatting-data) just in case somebody wants to share templates among both engines, although do not take that as an official support statement.
- Add a test that copies a folder with default data, then copies with altered data, and then copies again with default data and still the altered values have been used.
- This is a partial improvement towards completion of #88.

@Tecnativa TT20357