### PR TITLE
Basic support for automatic copy updates

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -1,92 +1,124 @@
 #!/usr/bin/env python
-from argparse import ArgumentParser
-from copy import deepcopy
+from plumbum import cli, colors
 import sys
 
-from .types import AnyByStrDict
+from .types import OptStr, AnyByStrDict
 from .main import copy
 from .version import __version__
 
 
-PARSER_BASE_CONFIG = {
-    "description": "Create a new project from a template.",
-    "usage": "copier project_template_path destination_path [options]",
-    "epilog": (
-        "Warning! Use only trusted project templates as they might "
-        "execute code with the same level of access as your user."
-    ),
-}
+class CopierApp(cli.Application):
+    DESCRIPTION = "Create a new project from a template."
+    DESCRIPTION_MORE = colors.yellow | """
+    WARNING! Use only trusted project templates, as they might
+    execute code with the same level of access as your user.
+    """
+    USAGE = """
+    copier [SWITCHES] [copy] template_src destination_path
+    copier [SWITCHES] [update] [destination_path]
+    """
+    VERSION = __version__
+    CALL_MAIN_IF_NESTED_COMMAND = False
+    data: AnyByStrDict = {}
 
-PARSER_ARG_CONFIG = (
-    # BASIC ARGS
-    {"args": ("--version",), "action": "version", "version": __version__},
-    {"args": ("source",), "help": "The path of the project template."},
-    {"args": ("dest",), "help": "The path of where to create the new project."},
-    # PATHS
-    {
-        "args": ("--extra-paths",),
-        "nargs": "*",
-        "help": "Additional directories to find parent templates in.",
-    },
-    {
-        "args": ("--exclude",),
-        "nargs": "*",
-        "help": (
-            "A list of names or shell-style patterns matching files or folders "
-            "that must not be copied."
+    extra_paths = cli.SwitchAttr(
+        ["-p", "--extra-paths"], str, list=True,
+        help="Additional directories to find parent templates in")
+    exclude = cli.SwitchAttr(
+        ["-x", "--exclude"], str, list=True,
+        help=(
+            "A name or shell-style pattern matching files or folders "
+            "that must not be copied"
         ),
-    },
-    {
-        "args": ("--include",),
-        "nargs": "*",
-        "help": (
-            "A list of names or shell-style patterns matching files or folders that "
-            "must be included, even if its name are in the `exclude` list."
+    )
+    include = cli.SwitchAttr(
+        ["-i", "--include"], str, list=True,
+        help=(
+            "A name or shell-style pattern matching files or folders "
+            "that must be included, even if their names are in the `exclude` list"
         ),
-    },
-    # FLAGS
-    {
-        "args": ("--pretend",),
-        "action": "store_true",
-        "help": "Run but do not make any changes."
-    },
-    {
-        "args": ("--force",),
-        "action": "store_true",
-        "help": "Overwrite files that already exist, without asking."
-    },
-    {
-        "args": ("--skip",),
-        "action": "store_true",
-        "help": "Skip files that already exist, without asking."
-    },
-    {
-        "args": ("--quiet",),
-        "action": "store_true",
-        "help": "Suppress status output."
-    },
-)
+    )
+
+    pretend = cli.Flag(
+        ["-n", "--pretend"],
+        help="Run but do not make any changes",
+    )
+    force = cli.Flag(
+        ["-f", "--force"],
+        help="Overwrite files that already exist, without asking",
+    )
+    skip = cli.Flag(
+        ["-s", "--skip"],
+        help="Skip files that already exist, without asking",
+    )
+    quiet = cli.Flag(
+        ["-q", "--quiet"],
+        help="Suppress status output",
+    )
+
+    @cli.switch(
+        ["-d", "--data"], str, "VARIABLE=VALUE", list=True,
+        help="Make VARIABLE available as VALUE when rendering the template")
+    def data_switch(self, values):
+        self.data.update(value.split("=", 1) for value in values)
+
+    def _copy(self, src_path: OptStr = None, dst_path: str = ".") -> None:
+        """Run Copier's internal API using CLI switches."""
+        return copy(
+            data=self.data,
+            dst_path=dst_path,
+            exclude=self.exclude,
+            extra_paths=self.extra_paths,
+            force=self.force,
+            include=self.include,
+            pretend=self.pretend,
+            quiet=self.quiet,
+            skip=self.skip,
+            src_path=src_path,
+        )
+
+    def main(self, *args) -> int:
+        """Copier shortcuts."""
+        # If using 0 or 1 args, you want to update
+        if len(args) in {0, 1}:
+            self.nested_command = (
+                self._subcommands["update"].subapplication,
+                ["copier update"] + list(args))
+        # If using 2 args, you want to copy
+        elif len(args) == 2:
+            self.nested_command = (
+                self._subcommands["copy"].subapplication,
+                ["copier copy"] + list(args))
+        # If using more args, you're wrong
+        else:
+            self.help()
+            print(colors.red | "Unsupported arguments", file=sys.stderr)
+            return 1
+        return 0
 
 
-def make_parser(base_config, arg_config) -> ArgumentParser:
-    parser = ArgumentParser(**base_config)
-    arg_config = deepcopy(arg_config)
-    for c in arg_config:
-        args = c.pop("args")
-        parser.add_argument(*args, **c)
-    return parser
+@CopierApp.subcommand("copy")
+class CopierCopySubApp(cli.Application):
+    DESCRIPTION = "Copy form a template source to a destination"
+
+    def main(self, template_src: str, destination_path: str) -> int:
+        self.parent._copy(template_src, destination_path)
+        return 0
 
 
-def get_cli_args(args_) -> AnyByStrDict:
-    parser = make_parser(PARSER_BASE_CONFIG, PARSER_ARG_CONFIG)
-    ns = parser.parse_args(args_)
-    return vars(ns)
+@CopierApp.subcommand("update")
+class CopierUpdateSubApp(cli.Application):
+    DESCRIPTION = "Update a copy from its original template"
+    DESCRIPTION_MORE = """
+    The copy must have a file called `.copier-answers.yml` which contains info
+    from the last Copier execution, including the source template
+    (it must be a key called `_src_path`).
+    """
 
-
-def run() -> None:  # pragma:no cover
-    kwargs = get_cli_args(sys.argv[1:])
-    copy(kwargs.pop("source"), kwargs.pop("dest"), **kwargs)
+    def main(self, destination_path: cli.ExistingDirectory = ".") -> int:
+        self.parent._copy(dst_path=destination_path)
+        return 0
 
 
 if __name__ == "__main__":
-    run()
+    CopierApp.run()

--- a/copier/config/factory.py
+++ b/copier/config/factory.py
@@ -1,7 +1,7 @@
 from typing import Any, Tuple
 
-from ..types import AnyByStrDict, OptAnyByStrDict, OptBool, OptStrSeq
-from .objects import DEFAULT_DATA, ConfigData, EnvOps, Flags
+from ..types import AnyByStrDict, OptAnyByStrDict, OptBool, OptStr, OptStrSeq
+from .objects import DEFAULT_DATA, ConfigData, EnvOps, Flags, NoSrcPathError
 from .user_data import load_config_data, load_logfile_data, query_user_data
 
 __all__ = ("make_config",)
@@ -20,8 +20,8 @@ def filter_config(data: AnyByStrDict) -> Tuple[AnyByStrDict, AnyByStrDict]:
 
 
 def make_config(
-    src_path: str,
-    dst_path: str,
+    src_path: OptStr = None,
+    dst_path: str = ".",
     *,
     data: OptAnyByStrDict = None,
     exclude: OptStrSeq = None,
@@ -35,6 +35,7 @@ def make_config(
     skip: OptBool = None,
     quiet: OptBool = None,
     cleanup_on_error: OptBool = None,
+    original_src_path: str = None,
     **kwargs,
 ) -> Tuple[ConfigData, Flags]:
     """Provides the configuration object, merged from the different sources.
@@ -42,10 +43,18 @@ def make_config(
     The order of precedence for the merger of configuration object is:
     function_args > user_data > defaults.
     """
-    args = {k: v for k, v in locals().items() if v is not None}
-
-    file_data = load_config_data(src_path, quiet=True)
     answers_data = load_logfile_data(dst_path, quiet=True)
+    if src_path is None:
+        try:
+            src_path = answers_data["_src_path"]
+            original_src_path = original_src_path or src_path
+        except KeyError:
+            raise NoSrcPathError(
+                "No .copier-answers.yml file found, or it didn't include "
+                "original template information (_src_path). "
+                "Run `copier copy` instead.",
+            )
+    file_data = load_config_data(src_path, quiet=True)
     config_data, query_data = filter_config(file_data)
     query_data.update(filter(
         lambda item: item[0] in query_data,
@@ -58,6 +67,7 @@ def make_config(
     # merge config sources in the order of precedence
     config_data["data"] = {**DEFAULT_DATA.copy(), **query_data, **(data or {})}
 
+    args = {k: v for k, v in locals().items() if v is not None}
     args = {**config_data, **args}
     args["envops"] = EnvOps(**args.get("envops", {}))
 

--- a/copier/config/objects.py
+++ b/copier/config/objects.py
@@ -6,7 +6,7 @@ from typing import Any, Tuple
 
 from pydantic import BaseModel, Extra, StrictBool, validator
 
-from ..types import AnyByStrDict, PathSeq, StrOrPathSeq, StrSeq
+from ..types import AnyByStrDict, PathSeq, StrOrPathSeq, StrSeq, OptStr
 
 # Default list of files in the template to exclude from the rendered project
 DEFAULT_EXCLUDE: Tuple[str, ...] = (
@@ -26,6 +26,10 @@ DEFAULT_DATA: AnyByStrDict = {
     "now": datetime.datetime.utcnow,
     "make_secret": lambda: sha512(urandom(48)).hexdigest(),
 }
+
+
+class NoSrcPathError(Exception):
+    pass
 
 
 class Flags(BaseModel):
@@ -70,6 +74,7 @@ class ConfigData(BaseModel):
     skip_if_exists: StrOrPathSeq = []
     tasks: StrSeq = []
     envops: EnvOps
+    original_src_path: OptStr
 
     def __init__(self, **data: Any):
         super().__init__(**data)

--- a/copier/types.py
+++ b/copier/types.py
@@ -14,6 +14,7 @@ PathSeq = Sequence[Path]
 # optional types
 OptBool = Optional[bool]
 OptStrOrPathSeq = Optional[StrOrPathSeq]
+OptStr = Optional[str]
 OptStrSeq = Optional[StrSeq]
 OptAnyByStrDict = Optional[AnyByStrDict]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     jinja2 ~= 2.10
     colorama ~= 0.4
     ruamel.yaml ~= 0.15
+    plumbum ~= 1.6
     pydantic >= 1.0b1
 
 [options.packages.find]
@@ -52,7 +53,7 @@ dev =
 
 [options.entry_points]
 console_scripts =
-    copier = copier.cli:run
+    copier = copier.cli:CopierApp.run
 
 
 [flake8]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,60 +4,15 @@ from shlex import split
 import pytest
 
 import copier
-from copier.cli import make_parser, get_cli_args, run
+from copier.cli import CopierApp
 
 SIMPLE_DEMO_PATH = Path(__file__).parent / "demo_simple"
 
 
-@pytest.mark.parametrize(
-    "base_config, arg_config, exception",
-    (
-        (None, ({},), TypeError),
-        ({}, None, TypeError),
-        ({}, ({},), KeyError),
-        ({}, ({"args": None},), TypeError),
-    ),
-)
-def test_make_parser_bad_config(base_config, arg_config, exception):
-    with pytest.raises(exception):
-        make_parser(base_config, arg_config)
-
-
-@pytest.mark.parametrize("args_", (None, {}, {"source": "."}, {"dest": "."}))
-def test_invalid_cli_args(args_):
-    with pytest.raises(SystemExit):
-        get_cli_args(args_)
-
-
-@pytest.mark.parametrize(
-    "arg, kw, expected",
-    (
-        # PATHS
-        ("--extra-paths a/ b/ c/", "extra_paths", ["a/", "b/", "c/"]),
-        ("--exclude a/ b/ c/", "exclude", ["a/", "b/", "c/"]),
-        ("--include a/ b/ c/", "include", ["a/", "b/", "c/"]),
-        # FLAGS
-        ("--pretend", "pretend", True),
-        ("--force", "force", True),
-        ("--skip", "skip", True),
-        ("--quiet", "quiet", True),
-    ),
-)
-def test_cli_args(arg, kw, expected):
-    args_ = f"src_path/ dst_path/ {arg}"
-    kwargs = get_cli_args(split(args_))
-    assert kw in kwargs
-    assert kwargs[kw] == expected
-
-
-def test_good_cli_run(dst, monkeypatch):
-    def fake_cli_args(*_args, **_kwargs):
-        return {"source": SIMPLE_DEMO_PATH, "dest": dst, "quiet": True}
-
-    monkeypatch.setattr(copier.cli, "get_cli_args", fake_cli_args)
-
-    run()
+def test_good_cli_run(dst):
+    run_result = CopierApp.run(["--quiet", str(SIMPLE_DEMO_PATH), str(dst)], exit=False)
     a_txt = dst / "a.txt"
+    assert run_result[1] == 0
     assert a_txt.exists()
     assert a_txt.is_file()
     assert a_txt.read_text().strip() == "EXAMPLE_CONTENT"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -180,6 +180,7 @@ def test_config_data_good_data(dst):
         "extra_paths": [dst],
         "exclude": DEFAULT_EXCLUDE,
         "include": [],
+        "original_src_path": None,
         "skip_if_exists": ["skip_me"],
         "tasks": ["echo python rulez"],
         "envops": EnvOps(),


### PR DESCRIPTION
TODO:

- [x] Remove from WIP when #103 is merged and commits from that PR are removed from this one.

---

This is a totally breaking PR. It had to come sooner or later...

Before this patch, copier had some ugly problems:

- If a file was called `--exclude`, you couldn't add it to `--extra-paths` due to using `nargs='*'` in an option. It is a weird thing that `ArgumentParser` allows to do, but can potentially lead to unfixable problems.
- Argument parsing was a little bit handycraft work.

Meet [Plumbum](https://plumbum.readthedocs.io/), the swiss army knife for CLI packages:

- CLI has been refactored as a plumbum application.
- The application now includes 2 subcommands: `copy` and `update`.
- If called without args, or with 1, it will use `update`.
- If called with 2 args, it will use `copy` (this preserves old usage unchanged, unless you are copying from a template called `copy` or `update`; in such corner case, just call it as `copier copy copy destination` instead).
- `copier --help` and `copier --help-all` are more useful now.

And you might be wondering... Adding such a big dependency just for that? Well, actually plumbum supports more than just CLI applications: supports sane execution of local & remote commands, sane output coloring, sane user prompting... Possibly it will make Copier go to the next level as we keep on using it more. Just take a look at its docs! You'll love it wink

Of course, all that new CLI had to be reflected in API changes:

- `src_path` is now optional (`None` by default). In such case, copier will try to guess the `src_path` from the `.copier-answers.yml` file in the copy, or fail otherwise.
- `dst_path` is also now optional (`.` by default), meaning that without a `src_path`, you'll be trying to copy anything else to current `$PWD`.
- The builtin `_log` variable, which contains all necessary data for copy updates, now has also a `_src_path` key that points to the original source. This only happens when it was copied from a git repo or from an absolute path in the local disk, as relative paths are not easily reproducible in next updates (they depend on the user's CWD when running copier).
- A new `original_src_path` variable goes around, indicating the git repo or abs system path passed to `src_path` on the initial call. This is just to be stored in `_log` as explained.

```bash
copier gh:example/template destination
cd destination
echo my changes >> anywhere
git commit -m changing .
copier # Equals to `copier update .`
git commit -m 'copier update' .
```

tada You're updated!

This is an importan step to complete #88.

---

@Tecnativa TT20357