### PR TITLE
Handle KeyboardInterrupt elegantly

### DIFF
--- a/copier/config/objects.py
+++ b/copier/config/objects.py
@@ -28,7 +28,13 @@ DEFAULT_DATA: AnyByStrDict = {
 }
 
 
-class NoSrcPathError(Exception):
+class UserMessageError(Exception):
+    """Exit the program giving a message to the user."""
+
+    pass
+
+
+class NoSrcPathError(UserMessageError):
     pass
 
 


### PR DESCRIPTION
Without this patch, a full traceback is printed when the user hits <kbd>Ctrl</kbd> + <kbd>C</kbd>.

Now it's more elegant:

![2020-01-17_08-48](https://user-images.githubusercontent.com/973709/72593876-67a9f500-3906-11ea-9789-cbf9d52ae907.png)


@Tecnativa TT20357