### PR TITLE
Reduce code complexity

### DIFF
--- a/copier/config/__init__.py
+++ b/copier/config/__init__.py
@@ -1,1 +1,1 @@
-from .factory import Flags, make_config  # noqa
+from .factory import make_config  # noqa

--- a/copier/config/factory.py
+++ b/copier/config/factory.py
@@ -5,7 +5,7 @@ from plumbum.cmd import git
 
 from .. import vcs
 from ..types import AnyByStrDict, OptAnyByStrDict, OptBool, OptStr, OptStrSeq
-from .objects import DEFAULT_DATA, ConfigData, EnvOps, Flags, NoSrcPathError
+from .objects import DEFAULT_DATA, ConfigData, EnvOps, NoSrcPathError
 from .user_data import load_answersfile_data, load_config_data, query_user_data
 
 __all__ = ("make_config",)
@@ -44,7 +44,7 @@ def make_config(
     cleanup_on_error: OptBool = None,
     vcs_ref: str = "HEAD",
     **kwargs,
-) -> Tuple[ConfigData, Flags]:
+) -> ConfigData:
     """Provides the configuration object, merged from the different sources.
 
     The order of precedence for the merger of configuration object is:
@@ -84,4 +84,4 @@ def make_config(
     args = {**config_data, **args}
     args["envops"] = EnvOps(**args.get("envops", {}))
     args["data"].update(config_data["data"])
-    return ConfigData(**args), Flags(**args)
+    return ConfigData(**args)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,14 +1,16 @@
 from pathlib import Path
 
 from copier import tools
-from copier.config.factory import EnvOps
+from copier.config.factory import ConfigData, EnvOps
 
 from .helpers import DATA, PROJECT_TEMPLATE
 
 
 def test_render(dst):
     envops = EnvOps().dict()
-    render = tools.get_jinja_renderer(PROJECT_TEMPLATE, DATA, envops=envops)
+    render = tools.Renderer(
+        ConfigData(src_path=PROJECT_TEMPLATE, dst_path=dst, data=DATA, envops=envops)
+    )
 
     assert render.string("/hello/[[ what ]]/") == "/hello/world/"
     assert render.string("/hello/world/") == "/hello/world/"


### PR DESCRIPTION
As explained in #110, the dangling parameters for methods keep on complicating development.

A full code refactoring is too much work for now, but I did a little refactoring which consists in:

- Merge `Flags` into `ConfigData`, and remove anything related exclusively to flags.
- Any method that uses arguments from `ConfigData` gets instead a `conf: ConfigData` argument.
- `get_jinja_renderer()` removed; it's not useful as its little work can easily be done by `Renderer` itself.

This way, whenever we need a new config, we can just add it to `ConfigData` and use it more widely.

A full refactoring is still needed IMHO, where we have a main `Copier` class which handles its state and everything it needs (or it could be `CopierApp` instead), but that's more a design decision to be taken by the project leader.

@Tecnativa TT20357