### PR TITLE
Exclude recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ _templates_suffix: .tmpl
 _exclude:
   - "*.bar"
   - ".git"
-  - ".git/*"
 
 # Shell-style patterns files/folders that *must be* copied, even if
 # they are in the exclude list
@@ -324,9 +323,6 @@ Uses the template in _src_path_ to generate a new project at _dst_path_.
 - **exclude** (list):<br>
   A list of names or shell-style patterns matching files or folders
   that must not be copied.
-
-  To exclude a folder you should use **two** entries, one for the folder and
-  the other for its content: `[".git", ".git/*"]`.
 
 - **include** (list):<br>
   A list of names or shell-style patterns matching files or folders that

--- a/copier/config/objects.py
+++ b/copier/config/objects.py
@@ -15,9 +15,7 @@ DEFAULT_EXCLUDE: Tuple[str, ...] = (
     "~*",
     "*.py[co]",
     "__pycache__",
-    "__pycache__/*",
     ".git",
-    ".git/*",
     ".DS_Store",
     ".svn",
 )

--- a/copier/main.py
+++ b/copier/main.py
@@ -153,12 +153,14 @@ def copy_local(conf: ConfigData) -> None:
 
     folder: StrOrPath
     rel_folder: StrOrPath
-    for folder, _, files in os.walk(conf.src_path):
+    for folder, sub_dirs, files in os.walk(conf.src_path):
         rel_folder = str(folder).replace(str(conf.src_path), "", 1).lstrip(os.path.sep)
         rel_folder = render.string(rel_folder)
         rel_folder = str(rel_folder).replace("." + os.path.sep, ".", 1)
 
         if must_filter(rel_folder):
+            # Folder is excluded, so stop walking it
+            sub_dirs[:] = []
             continue
 
         folder = Path(folder)

--- a/tests/demo_exclude/bad/subdir/file.txt
+++ b/tests/demo_exclude/bad/subdir/file.txt
@@ -1,0 +1,1 @@
+This file must not exist in copy.

--- a/tests/demo_exclude/copier.yml
+++ b/tests/demo_exclude/copier.yml
@@ -1,0 +1,2 @@
+_exclude:
+  - bad

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -1,0 +1,12 @@
+from copier.main import copy
+
+from .helpers import PROJECT_TEMPLATE
+
+SRC = f"{PROJECT_TEMPLATE}_exclude"
+
+
+def test_recursive_exclude(tmp_path):
+    """Copy is done properly when excluding recursively."""
+    copy(SRC, tmp_path)
+    assert not (tmp_path / "bad").is_dir()
+    assert not (tmp_path / "bad").exists()


### PR DESCRIPTION
Excluding a folder and its contents didn't exclude its subfolders.

Now, excluding a folder excludes all its files and subfolders.

@Tecnativa TT20357