### PR TITLE
Implement build + publish via CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,18 +34,29 @@ jobs:
           poetry run pytest --color=yes .
 
   publish:
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    if: github.event_name == 'merge' && startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.8]
-
     steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry
+          poetry install
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry
+          poetry install
       - name: Build dist
         run: |
           poetry build
       - name: Publish distribution 📦 to Test PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:
+          user: __token__
           password: ${{ secrets.test_pypi_token_copier }}
-        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
     branches: [master]
+  release:
+    types: [created]
 
 jobs:
   build:
@@ -34,7 +36,7 @@ jobs:
           poetry run pytest --color=yes .
 
   publish:
-    if: github.event_name == 'merge' && startsWith(github.event.ref, 'refs/tags')
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,20 @@ jobs:
       - name: Run pytest
         run: |
           poetry run pytest --color=yes .
+
+  publish:
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - name: Build dist
+        run: |
+          poetry build
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.test_pypi_token_copier }}
+        repository_url: https://test.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8"
 ]
 authors = ["Ben Felder <ben@felder.io>"]
+homepage = "https://github.com/pykong/copier"
 repository = "https://github.com/pykong/copier"
 readme = "README.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,5 +62,5 @@ max-line-length = 88
 ignore = ",W503,E203,D100,D101,D102,D103,D104,D105,D107,"
 
 [build-system]
-requires = ["setuptools>=34.4", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["poetry>=1.0.3"]
+build-backend = "poetry.masonry.api"


### PR DESCRIPTION
This **PR** implements building `copier` via `poetry`.
The build is published via a GitHub Action to Test-PyPI and then PyPI.
The build should only be triggered on tagged commits being merged into `master`.

Note: Right now I am waiting for a transfer of the copier project on Test-PyPI from the original author @jpscaletti. Until then this **PR** will not be merged.

See also:
- https://github.com/pypa/gh-action-pypi-publish

Closes: #130 