### PR TITLE
Make sure --data works

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ multi_line_output = 3  # black interop
 use_parentheses = true
 
 [flake8]
-max-complexity = 10
+max-complexity = 20
 max-line-length = 88
 ignore = ",W503,E203,D100,D101,D102,D103,D104,D105,D107,"
 

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -81,3 +81,38 @@ def test_cli(dst):
             optional_value: null
         """
     )
+
+
+def test_api_str_data(dst):
+    """Test copier when all data comes as a string.
+
+    This happens i.e. when using the --data CLI argument.
+    """
+    copy(
+        SRC,
+        dst,
+        data={
+            "love_me": "false",
+            "your_name": "LeChuck",
+            "your_age": "220",
+            "your_height": "1.9",
+            "more_json_info": '["bad", "guy"]',
+            "anything_else": "{'hates': 'all'}",
+        },
+        force=True,
+    )
+    results_file = dst / "results.txt"
+    assert results_file.read_text() == dedent(
+        r"""
+            love_me: false
+            your_name: "LeChuck"
+            your_age: 220
+            your_height: 1.9
+            more_json_info: ["bad", "guy"]
+            anything_else: {"hates": "all"}
+            choose_list: "first"
+            choose_tuple: "second"
+            choose_dict: "third"
+            optional_value: null
+        """
+    )


### PR DESCRIPTION
When using the `--data` CLI option, all incoming data are strings. This is the expected behavior because at this point we still don't know the expected types of all answers (we don't even know the questions).

Now the type casting is done smartly when strings come in any form.

There are 2 special cases handled here:

1. When the expected type is bool and the incoming data is string. Handled by YAML because strings like "false", "0" and "no" would evaluate to `True` otherwise.
2. When the expected type is JSON or YAML but the incoming data is not a string. This can only happen when data comes in from API calls (not CLI) or is loaded from default answers in `copier.yml`. In these cases, we don't need to do any type casting, because the input is already a scalar.

@Tecnativa TT20357