### PR TITLE
Update changelog for 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The code base also received a lot of love and hardening.
 - Introduced gitignore-style patterns for `exclude` und `skip-if-exists`.
 - Dropped support for `include` option.
 - Added support for extending content of config files via content of other files via `pyaml-include`.
+- Customizable template extension.
+- Ability to remember last answers.
+- Template upgrades support, (based on the previous point) with migration tasks specification.
+- Extended questions format, supporting help, format, choices and secrets.
+- More beautiful prompts.
+- New CLI experience.
 
 #### Other:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The code base also received a lot of love and hardening.
 - Added `pre-commit` for enforced linting.
 - Added `prettier`, `black` and `isort` for code formatting.
 - Added `pytest` for running tests.
+- Use `plumbum` as CLI and subprocess engine.
 
 ### Version 2.5 (2019-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,30 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-### Version 3.0 (2020-03)
+### Version 3.0.0 (2020-03)
 
-- Dropped support for Python 3.5.
+This is a big release with many new features added and improved.
+The code base also received a lot of love and hardening.
+
+#### Features:
+
+- Minimal supported Python version is now 3.6.
 - Dropped support for deprecated `voodoo.json`.
-- Type annotated entire code base.
-- Increased test coverage.
 - Supporting self-templating.
 - Introduced gitignore-style patterns for `exclude` und `skip-if-exists`.
 - Dropped support for `include` option.
-- Ditched `ruamel.yaml` for `PyYaml`.
 - Added support for extending content of config files via content of other files via `pyaml-include`.
+
+#### Other:
+
+- Moved to `poetry` for package management.
+- Type annotated entire code base.
+- Increased test coverage.
+- Ditched `ruamel.yaml` for `PyYaml`.
+- Ditched Travis CI for GitHub Actions.
+- Added `pre-commit` for enforced linting.
+- Added `black` and `isort` for code formatting.
+- Added `pytest` for running tests.
 
 ### Version 2.5 (2019-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,17 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-### Version 3.0 (2019-xx)
+### Version 3.0 (2020-03)
 
 - Dropped support for Python 3.5.
 - Dropped support for deprecated `voodoo.json`.
 - Type annotated entire code base.
+- Increased test coverage.
+- Supporting self-templating.
+- Introduced gitignore-style patterns for `exclude` und `skip-if-exists`.
+- Dropped support for `include` option.
+- Ditched `ruamel.yaml` for `PyYaml`.
+- Added support for extending content of config files via content of other files via `pyaml-include`.
 
 ### Version 2.5 (2019-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ The code base also received a lot of love and hardening.
 
 - Minimal supported Python version is now 3.6.
 - Dropped support for deprecated `voodoo.json`.
-- Supporting self-templating.
 - Introduced gitignore-style patterns for `exclude` und `skip-if-exists`.
 - Dropped support for `include` option.
 - Added support for extending content of config files via content of other files via `pyaml-include`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The code base also received a lot of love and hardening.
 - Ditched `ruamel.yaml` for `PyYaml`.
 - Ditched Travis CI for GitHub Actions.
 - Added `pre-commit` for enforced linting.
-- Added `black` and `isort` for code formatting.
+- Added `prettier`, `black` and `isort` for code formatting.
 - Added `pytest` for running tests.
 
 ### Version 2.5 (2019-06)


### PR DESCRIPTION
As `3.0.0` is going to be a big release I have substructured the section into user-facing changes ("features") and developer-facing ones ("other").

@Yajo Could you add the changes you have made leading up to the release of `3.0.0.`, so far?
