### PR TITLE
Add secret questions support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,12 +13,12 @@ repos:
     hooks:
       - id: black
         name: black
-        entry: black
+        entry: poetry run black
         language: system
         types: [python]
       - id: flake8
         name: flake8
-        entry: flake8
+        entry: poetry run flake8
         language: system
         types: [python]
         args: ["--config", "pyproject.toml"]

--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ project_name:
   help: An awesome project needs an awesome name. Tell me yours.
   default: paradox-specifier
 
+rocket_launch_password:
+  type: str
+  secret: true # This value will not be logged into .copier-answers.yml
+  default: my top secret password
+
 # I'll avoid default and help here, but you can use them too
 age:
   type: int

--- a/copier/config/factory.py
+++ b/copier/config/factory.py
@@ -13,16 +13,20 @@ __all__ = ("make_config",)
 
 def filter_config(data: AnyByStrDict) -> Tuple[AnyByStrDict, AnyByStrDict]:
     """Separates config and questions data."""
-    conf_data = {}
+    conf_data: AnyByStrDict = {"secret_questions": set()}
     questions_data = {}
     for k, v in data.items():
-        if k.startswith("_"):
+        if k == "_secret_questions":
+            conf_data["secret_questions"].update(v)
+        elif k.startswith("_"):
             conf_data[k[1:]] = v
         else:
             # Transform simplified questions format into complex
             if not isinstance(v, dict):
                 v = {"default": v}
             questions_data[k] = v
+            if v.get("secret"):
+                conf_data["secret_questions"].add(k)
     return conf_data, questions_data
 
 

--- a/copier/config/objects.py
+++ b/copier/config/objects.py
@@ -80,6 +80,7 @@ class ConfigData(BaseModel):
     skip: StrictBool = False
     vcs_ref: OptStr
     migrations: Sequence[Migrations] = ()
+    secret_questions: StrSeq = ()
 
     def __init__(self, **data: Any):
         super().__init__(**data)

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -125,6 +125,7 @@ class Renderer:
             (k, v)
             for (k, v) in conf.data.items()
             if not k.startswith("_")
+            and k not in conf.secret_questions
             and isinstance(k, JSONSerializable)
             and isinstance(v, JSONSerializable)
         )

--- a/tests/demo_answersfile/copier.yml
+++ b/tests/demo_answersfile/copier.yml
@@ -3,3 +3,12 @@ round: 1st
 # A str question without a default should default to None
 str_question_without_default:
   type: str
+
+# password_1 and password_2 must not appear in answers file
+_secret_questions:
+  - password_1
+
+password_1: password one
+password_2:
+  secret: yes
+  default: password two

--- a/tests/demo_answersfile/round.txt.tmpl
+++ b/tests/demo_answersfile/round.txt.tmpl
@@ -1,1 +1,3 @@
 It's the [[round]] round.
+password_1=[[password_1]]
+password_2=[[password_2]]

--- a/tests/test_answersfile.py
+++ b/tests/test_answersfile.py
@@ -1,3 +1,5 @@
+from textwrap import dedent
+
 import copier
 from copier.config.user_data import load_answersfile_data
 
@@ -12,21 +14,54 @@ def test_answersfile(dst):
 
     # Check 1st round is properly executed and remembered
     copier.copy(SRC, dst, force=True)
-    assert round_file.read_text() == "It's the 1st round.\n"
+    assert (
+        round_file.read_text()
+        == dedent(
+            """
+            It's the 1st round.
+            password_1=password one
+            password_2=password two
+            """
+        ).lstrip()
+    )
     log = load_answersfile_data(dst)
     assert log["round"] == "1st"
     assert log["str_question_without_default"] is None
+    assert "password_1" not in log
+    assert "password_2" not in log
 
     # Check 2nd round is properly executed and remembered
     copier.copy(SRC, dst, {"round": "2nd"}, force=True)
-    assert round_file.read_text() == "It's the 2nd round.\n"
+    assert (
+        round_file.read_text()
+        == dedent(
+            """
+            It's the 2nd round.
+            password_1=password one
+            password_2=password two
+            """
+        ).lstrip()
+    )
     log = load_answersfile_data(dst)
     assert log["round"] == "2nd"
     assert log["str_question_without_default"] is None
+    assert "password_1" not in log
+    assert "password_2" not in log
 
     # Check repeating 2nd is properly executed and remembered
     copier.copy(SRC, dst, force=True)
-    assert round_file.read_text() == "It's the 2nd round.\n"
+    assert (
+        round_file.read_text()
+        == dedent(
+            """
+            It's the 2nd round.
+            password_1=password one
+            password_2=password two
+            """
+        ).lstrip()
+    )
     log = load_answersfile_data(dst)
     assert log["round"] == "2nd"
     assert log["str_question_without_default"] is None
+    assert "password_1" not in log
+    assert "password_2" not in log

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -184,6 +184,7 @@ def test_config_data_good_data(dst):
         "skip": False,
         "vcs_ref": None,
         "migrations": (),
+        "secret_questions": (),
     }
     conf = ConfigData(**expected)
     expected["data"]["_folder_name"] = dst.name


### PR DESCRIPTION


Secrets questions are available in the jinja render context, but are not logged into `.copier-answers.yml` by default.

To mark a question as secret, just set `secret: true` into its definition. You can also pass a list of question keys in `_secret_questions` if you prefer.

@Tecnativa TT20357

---

Also included:  Run linters under poetry venv 