### PR TITLE
Allow CLI to display version with `copier --version`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,18 +16,21 @@ repos:
         entry: poetry run black
         language: system
         types: [python]
+        require_serial: true
       - id: flake8
         name: flake8
         entry: poetry run flake8
         language: system
         types: [python]
         args: ["--config", "pyproject.toml"]
+        require_serial: true
       - id: poetry_check
         description: Check the integrity of pyproject.toml
         name: poetry_check
         entry: poetry check
         language: system
         pass_filenames: false
+        require_serial: true
 
   # isorting our imports
   - repo: https://github.com/timothycrosley/isort

--- a/copier/__init__.py
+++ b/copier/__init__.py
@@ -2,3 +2,6 @@
 """
 from .main import *  # noqa
 from .tools import *  # noqa
+
+# This version is a placeholder autoupdated by poetry-dynamic-versioning
+__version__ = "0.0.0"

--- a/copier/cli.py
+++ b/copier/cli.py
@@ -4,6 +4,7 @@ from textwrap import dedent
 
 from plumbum import cli, colors
 
+from . import __version__
 from .config.objects import UserMessageError
 from .main import copy
 from .types import AnyByStrDict, OptStr
@@ -37,6 +38,7 @@ class CopierApp(cli.Application):
         copier [SWITCHES] [update] [destination_path]
         """
     )
+    VERSION = __version__
     CALL_MAIN_IF_NESTED_COMMAND = False
     data: AnyByStrDict = {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool]
 [tool.poetry]
 name = "copier"
+# This version is a placeholder autoupdated by poetry-dynamic-versioning
 version = "0.0.0"
 description = "A library for rendering project templates."
 license = "MIT"


### PR DESCRIPTION
This is a regression from #162 where `__version__` was removed due to conflicts with how black and poetry-dynamic-versioning work.

Now those conflicts are fixed and `copier --version` works again. This was what it was returning before:

```bash
➤ copier --version
copier (version not set)
```

BEWARE: In a development, it will always return `0.0.0`, but this is expected because poetry-dynamic-versioning autopatches this on release.

In `.pre-commit-config.yaml`, `require_serial: true` is added to all local tasks that run under `poetry run`. This is because when entering `poetry run`, poetry-dynamic-versioning does its magic and patches the versions in `pyproject.toml` and `__init__.py`, and unpatches them when ending the execution. If running in parallel (default pre-commit behavior), some patches are reverted and some aren't, producing random failed lints.

@Tecnativa TT20357