### PR TITLE
Fix --answers-file

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -42,7 +42,7 @@ class CopierApp(cli.Application):
     CALL_MAIN_IF_NESTED_COMMAND = False
     data: AnyByStrDict = {}
 
-    answers_file = cli.Flag(
+    answers_file = cli.SwitchAttr(
         ["-a", "--answers-file"],
         default=None,
         help=(

--- a/tests/demo_simple/[[ _copier_conf.answers_file ]].tmpl
+++ b/tests/demo_simple/[[ _copier_conf.answers_file ]].tmpl
@@ -1,0 +1,2 @@
+# Changes here will be overwritten by Copier
+[[ _copier_answers|to_nice_yaml ]]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import yaml
 from plumbum.cmd import copier as copier_cmd
 
 from copier.cli import CopierApp
@@ -8,12 +9,17 @@ SIMPLE_DEMO_PATH = Path(__file__).parent / "demo_simple"
 
 
 def test_good_cli_run(dst):
-    run_result = CopierApp.run(["--quiet", str(SIMPLE_DEMO_PATH), str(dst)], exit=False)
+    run_result = CopierApp.run(
+        ["--quiet", "-a", "altered-answers.yml", str(SIMPLE_DEMO_PATH), str(dst)],
+        exit=False,
+    )
     a_txt = dst / "a.txt"
     assert run_result[1] == 0
     assert a_txt.exists()
     assert a_txt.is_file()
     assert a_txt.read_text().strip() == "EXAMPLE_CONTENT"
+    answers = yaml.safe_load((dst / "altered-answers.yml").read_text())
+    assert answers["_src_path"] == str(SIMPLE_DEMO_PATH)
 
 
 def test_help():


### PR DESCRIPTION
This is a switch attribute, not a flag.

Without this patch, using this feature yields this error:

```
➤ copier -fa .altered-copier-answers.yml update
Traceback (most recent call last):
  File "/home/yajo/.local/bin/copier", line 8, in <module>
    sys.exit(CopierApp.run())
  File "/home/yajo/.local/pipx/venvs/copier/lib64/python3.7/site-packages/plumbum/cli/application.py", line 577, in run
    inst, retcode = subapp.run(argv, exit=False)
  File "/home/yajo/.local/pipx/venvs/copier/lib64/python3.7/site-packages/plumbum/cli/application.py", line 572, in run
    retcode = inst.main(*tailargs)
  File "/home/yajo/.local/pipx/venvs/copier/lib64/python3.7/site-packages/copier/cli.py", line 17, in _wrapper
    return method(*args, **kwargs)
  File "/home/yajo/.local/pipx/venvs/copier/lib64/python3.7/site-packages/copier/cli.py", line 172, in main
    dst_path=destination_path, only_diff=self.only_diff,
  File "/home/yajo/.local/pipx/venvs/copier/lib64/python3.7/site-packages/copier/cli.py", line 111, in _copy
    **kwargs,
  File "/home/yajo/.local/pipx/venvs/copier/lib64/python3.7/site-packages/copier/main.py", line 123, in copy
    conf = make_config(**locals())
  File "/home/yajo/.local/pipx/venvs/copier/lib64/python3.7/site-packages/copier/config/factory.py", line 59, in make_config
    answers_data.update(load_answersfile_data(dst_path, answers_file))
  File "/home/yajo/.local/pipx/venvs/copier/lib64/python3.7/site-packages/copier/config/user_data.py", line 90, in load_answersfile_data
    with open(Path(dst_path) / (answers_file or ".copier-answers.yml")) as fd:
  File "/usr/lib64/python3.7/pathlib.py", line 920, in __truediv__
    return self._make_child((key,))
  File "/usr/lib64/python3.7/pathlib.py", line 699, in _make_child
    drv, root, parts = self._parse_args(args)
  File "/usr/lib64/python3.7/pathlib.py", line 653, in _parse_args
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not bool
```

@Tecnativa TT20357