### PR TITLE
Fix updates getting diffed without proper answers

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -202,6 +202,7 @@ def update_diff(conf: ConfigData):
     with tempfile.TemporaryDirectory() as dst_temp:
         copy(
             dst_path=dst_temp,
+            data=conf.data.copy(),
             force=True,
             quiet=True,
             skip=False,

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -11,7 +11,8 @@ from .helpers import PROJECT_TEMPLATE
 REPO_BUNDLE_PATH = Path(f"{PROJECT_TEMPLATE}_updatediff_repo.bundle").absolute()
 
 
-def test_updatediff(dst: Path):
+def test_updatediff(tmpdir):
+    dst = Path(tmpdir)
     target = dst / "target"
     readme = target / "README.txt"
     answers = target / ".copier-answers.yml"
@@ -92,24 +93,29 @@ def test_updatediff(dst: Path):
         assert not (target / "after-v0.0.2").is_file()
         assert not (target / "before-v1.0.0").is_file()
         assert not (target / "after-v1.0.0").is_file()
-    # Check it's updated OK
-    assert answers.read_text() == dedent(
-        f"""
-            # Changes here will be overwritten by Copier
-            _commit: v0.0.2-1-g81c335d
-            _src_path: {REPO_BUNDLE_PATH}
-            author_name: Guybrush
-            project_name: to become a pirate
-        """
-    )
-    assert readme.read_text() == dedent(
-        """
-        Let me introduce myself.
+        # Check it's updated OK
+        assert answers.read_text() == dedent(
+            f"""
+                # Changes here will be overwritten by Copier
+                _commit: v0.0.2-1-g81c335d
+                _src_path: {REPO_BUNDLE_PATH}
+                author_name: Guybrush
+                project_name: to become a pirate
+            """
+        )
+        assert readme.read_text() == dedent(
+            """
+            Let me introduce myself.
 
-        My name is Guybrush.
+            My name is Guybrush.
 
-        My project is to become a pirate.
+            My project is to become a pirate.
 
-        Thanks for your grog.
-        """
-    )
+            Thanks for your grog.
+            """
+        )
+        commit("-m", "Update template to v0.0.2-1-g81c335d")
+        assert not git("status", "--porcelain")
+        # No more updates exist, so updating again should change nothing
+        CopierApp.invoke(force=True, vcs_ref="HEAD")
+        assert not git("status", "--porcelain")


### PR DESCRIPTION
There was a bug in how update diff was computed. As you can see, the temporary copy that was made to produce that diff didn't get the same answers as the current project. Thus, every time the user answered something different, a diff was generated and a `.rej` file was created.

Just try this and you'll see:

```bash
copier -f update
git add .
git commit -m updated
copier -f update
git status
```

The 2nd time you update, all files should be identical and untouched. However, that wasn't the case.

I took the chance to update this test's fixture from `dst` to `tmpdir`, which is more standard and comfortable to debug.

@Tecnativa TT20357