### PR TITLE
Fix updatediff when using copier update with --data

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -14,6 +14,7 @@ from plumbum.cmd import git
 from . import vcs
 from .config import make_config
 from .config.objects import ConfigData, UserMessageError
+from .config.user_data import load_answersfile_data
 from .tools import (
     Renderer,
     Style,
@@ -198,11 +199,12 @@ def update_diff(conf: ConfigData):
                     "Destination repository is dirty; cannot continue. "
                     "Please commit or stash your local changes and retry."
                 )
+    last_answers = load_answersfile_data(conf.dst_path, conf.answers_file)
     # Copy old template into a temporary destination
     with tempfile.TemporaryDirectory(prefix=f"{__name__}.update_diff.") as dst_temp:
         copy(
             dst_path=dst_temp,
-            data=conf.data.copy(),
+            data=last_answers,
             force=True,
             quiet=True,
             skip=False,

--- a/copier/main.py
+++ b/copier/main.py
@@ -199,7 +199,7 @@ def update_diff(conf: ConfigData):
                     "Please commit or stash your local changes and retry."
                 )
     # Copy old template into a temporary destination
-    with tempfile.TemporaryDirectory() as dst_temp:
+    with tempfile.TemporaryDirectory(prefix=f"{__name__}.update_diff.") as dst_temp:
         copy(
             dst_path=dst_temp,
             data=conf.data.copy(),

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -32,7 +32,7 @@ def is_git_repo_root(path: Path) -> bool:
 
 def is_git_bundle(path: Path) -> bool:
     """Indicate if a path is a valid git bundle."""
-    with tempfile.TemporaryDirectory() as dirname:
+    with tempfile.TemporaryDirectory(prefix=f"{__name__}.is_git_bundle.") as dirname:
         with local.cwd(dirname):
             git("init")
             return bool(git["bundle", "verify", path] & TF)
@@ -71,7 +71,7 @@ def checkout_latest_tag(local_repo: StrOrPath) -> str:
 
 
 def clone(url: str, ref: str = "HEAD") -> str:
-    location = tempfile.mkdtemp()
+    location = tempfile.mkdtemp(prefix=f"{__name__}.clone.")
     shutil.rmtree(location)  # Path must not exist
     git("clone", "--no-checkout", url, location)
     with local.cwd(location):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def dst(request):
     """Return a real temporary folder path which is unique to each test
     function invocation. This folder is deleted after the test has finished.
     """
-    dst = mkdtemp()
+    dst = mkdtemp(prefix=f"{__name__}.dst.")
     request.addfinalizer(lambda: shutil.rmtree(dst, ignore_errors=True))
     return Path(dst)
 

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -4,6 +4,7 @@ from textwrap import dedent
 from plumbum import local
 from plumbum.cmd import git
 
+from copier import copy
 from copier.cli import CopierApp
 
 from .helpers import PROJECT_TEMPLATE
@@ -119,3 +120,20 @@ def test_updatediff(tmpdir):
         # No more updates exist, so updating again should change nothing
         CopierApp.invoke(force=True, vcs_ref="HEAD")
         assert not git("status", "--porcelain")
+        # If I change an option, it updates properly
+        copy(
+            data={"author_name": "Largo LaGrande", "project_name": "to steal a lot"},
+            force=True,
+            vcs_ref="HEAD",
+        )
+        assert readme.read_text() == dedent(
+            """
+            Let me introduce myself.
+
+            My name is Largo LaGrande.
+
+            My project is to steal a lot.
+
+            Thanks for your grog.
+            """
+        )


### PR DESCRIPTION


When somebody calls `copier update` to reapply a template, respecting subproject evolution, but just to apply some changes to some answers, the updatediff system reverted those changes.

Now they are respected, so if calling `copier update` with new data, that new data will be applied to the subproject.

The basic fix is that when creating the temporary copy in the old commit (the one used to compare), it is created using last answers obtained from the subproject, excluding any new answers passed by the user.

#169 improved the situation but certainly it didn't fix it completely. This hardened test proves it works better now.



@Tecnativa TT20357