### PR TITLE
Update diff fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           path: ~/.local
           key: local-${{ env.PY }}|${{ hashFiles('pyproject.toml') }}|${{ hashFiles('poetry.lock') }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - run: git config --global user.name copier-ci
+      - run: git config --global user.email copier@copier
       - run: python -m pip install poetry poetry-dynamic-versioning
       - run: poetry install
       - name: Run pre-commit

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           path: ~/.cache
           key: ${{ env.PY }}|${{ hashFiles('pyproject.toml') }}|${{ hashFiles('poetry.lock') }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - run: git config --global user.name copier-ci
+      - run: git config --global user.email copier@copier
       - run: poetry install
       - name: Generate coverage report
         run: |

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,9 +1,12 @@
 import filecmp
 import os
+import textwrap
 from hashlib import sha1
 from pathlib import Path
+from typing import Dict
 
 import copier
+from copier.types import StrOrPath
 
 PROJECT_TEMPLATE = Path(__file__).parent / "demo"
 
@@ -27,3 +30,14 @@ def assert_file(dst, *path):
     p1 = os.path.join(str(dst), *path)
     p2 = os.path.join(str(PROJECT_TEMPLATE), *path)
     assert filecmp.cmp(p1, p2)
+
+
+def build_file_tree(spec: Dict[StrOrPath, str], dedent: bool = True):
+    """Builds a file tree based on the received spec."""
+    for path, contents in spec.items():
+        path = Path(path)
+        if dedent:
+            contents = textwrap.dedent(contents)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w") as fd:
+            fd.write(contents)

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -7,7 +7,7 @@ from plumbum.cmd import git
 from copier import copy
 from copier.cli import CopierApp
 
-from .helpers import PROJECT_TEMPLATE
+from .helpers import PROJECT_TEMPLATE, build_file_tree
 
 REPO_BUNDLE_PATH = Path(f"{PROJECT_TEMPLATE}_updatediff_repo.bundle").absolute()
 
@@ -137,3 +137,140 @@ def test_updatediff(tmpdir):
             Thanks for your grog.
             """
         )
+
+
+def test_commit_hooks_respected(tmp_path: Path):
+    """Commit hooks are taken into account when producing the update diff."""
+    # Prepare source template v1
+    src, dst = tmp_path / "src", tmp_path / "dst"
+    src.mkdir()
+    with local.cwd(src):
+        build_file_tree(
+            {
+                "copier.yml": """
+                _tasks:
+                  - git init
+                  - pre-commit install
+                  - pre-commit run -a || true
+                what: grog
+                """,
+                "[[ _copier_conf.answers_file ]].tmpl": """
+                [[ _copier_answers|to_nice_yaml ]]
+                """,
+                ".pre-commit-config.yaml": r"""
+                repos:
+                - repo: https://github.com/prettier/prettier
+                  rev: 2.0.4
+                  hooks:
+                    - id: prettier
+                - repo: local
+                  hooks:
+                    - id: forbidden-files
+                      name: forbidden files
+                      entry: found forbidden files; remove them
+                      language: fail
+                      files: "\\.rej$"
+                """,
+                "life.yml.tmpl": """
+                # Following code should be reformatted by pre-commit after copying
+                Line 1:      hello
+                Line 2:      [[ what ]]
+                Line 3:      bye
+                """,
+            }
+        )
+        git("init")
+        git("add", ".")
+        git("commit", "-m", "commit 1")
+        git("tag", "v1")
+    # Copy source template
+    copy(src_path=str(src), dst_path=dst, force=True)
+    with local.cwd(dst):
+        life = Path("life.yml")
+        git("add", ".")
+        # 1st commit fails because pre-commit reformats life.yml
+        git("commit", "-am", "failed commit", retcode=1)
+        # 2nd commit works because it's already formatted
+        git("commit", "-am", "copied v1")
+        assert life.read_text() == dedent(
+            """\
+            # Following code should be reformatted by pre-commit after copying
+            Line 1: hello
+            Line 2: grog
+            Line 3: bye
+            """
+        )
+    # Evolve source template to v2
+    with local.cwd(src):
+        build_file_tree(
+            {
+                "life.yml.tmpl": """
+                # Following code should be reformatted by pre-commit after copying
+                Line 1:     hello world
+                Line 2:     grow up
+                Line 3:     [[ what ]]
+                Line 4:     grow old
+                Line 5:     bye bye world
+                """,
+            }
+        )
+        git("init")
+        git("add", ".")
+        git("commit", "-m", "commit 2")
+        git("tag", "v2")
+    # Update subproject to v2
+    copy(dst_path=dst, force=True)
+    with local.cwd(dst):
+        git("commit", "-am", "copied v2")
+        assert life.read_text() == dedent(
+            """\
+            # Following code should be reformatted by pre-commit after copying
+            Line 1: hello world
+            Line 2: grow up
+            Line 3: grog
+            Line 4: grow old
+            Line 5: bye bye world
+            """
+        )
+        # No .rej files created (update diff was smart)
+        assert not git("status", "--porcelain")
+        # Subproject evolves
+        life.write_text(
+            dedent(
+                """\
+                Line 1: hello world
+                Line 2: grow up
+                Line 2.5: make friends
+                Line 3: grog
+                Line 4: grow old
+                Line 4.5: no more work
+                Line 5: bye bye world
+                """
+            )
+        )
+        git("commit", "-am", "subproject is evolved")
+        # Subproject re-updates just to change some values
+        copy(data={"what": "study"}, force=True)
+        git("commit", "-am", "re-updated to change values after evolving")
+        # Subproject evolution was respected up to sane possibilities.
+        # In an ideal world, this file would be exactly the same as what's written
+        # a few lines above, just changing "grog" for "study". However, that's nearly
+        # impossible to achieve, because each change hunk needs at least 1 line of
+        # context to let git apply that patch smartly, and that context couldn't be
+        # found because we changed data when updating, so the sanest thing we can
+        # do is to provide a .rej file to notify those
+        # unresolvable diffs. OTOH, some other changes are be applied.
+        # If some day you are able to produce that ideal result, you should be
+        # happy to modify these asserts.
+        assert life.read_text() == dedent(
+            """\
+            Line 1: hello world
+            Line 2: grow up
+            Line 3: study
+            Line 4: grow old
+            Line 4.5: no more work
+            Line 5: bye bye world
+            """
+        )
+        # This time a .rej file is unavoidable
+        assert Path(f"{life}.rej").is_file()


### PR DESCRIPTION
- Do not produce contextless diff (`--unified=0`), as it leads to weird results sometimes. `.rej` files provide a saner output. Actually https://git-scm.com/docs/git-apply#Documentation/git-apply.txt---unidiff-zero recommends not using contextless patches.
- Ask `git diff` to *never* join 2 code hunks, even if they are only separated by 1 line (`--inter-hunk-context=-1`). This gives Copier most chances to reduce the amount of rejected hunks.
- When a template is to be reformatted by a pre-commit hook after copy, make sure git hooks are respected, so the updated diff matches reality more closely.
- Add and use a new helper to comfortably build a file tree from a test, to provide a way to avoid having dangling sample trees and git samples.

@Tecnativa TT20357