### PR TITLE
Update docs and add better autoformatting for them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,21 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: generate cache key PY
-        run: echo "::set-env name=PY::$((python -VV; pip freeze) | sha256sum | cut -d' '
+        run:
+          echo "::set-env name=PY::$((python -VV; pip freeze) | sha256sum | cut -d' '
           -f1)"
       - uses: actions/cache@v1
         with:
           path: ~/.cache
-          key: cache-${{ env.PY }}|${{ hashFiles('pyproject.toml') }}|${{ hashFiles('poetry.lock') }}|${{ hashFiles('.pre-commit-config.yaml') }}
+          key:
+            cache-${{ env.PY }}|${{ hashFiles('pyproject.toml') }}|${{
+            hashFiles('poetry.lock') }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - uses: actions/cache@v1
         with:
           path: ~/.local
-          key: local-${{ env.PY }}|${{ hashFiles('pyproject.toml') }}|${{ hashFiles('poetry.lock') }}|${{ hashFiles('.pre-commit-config.yaml') }}
+          key:
+            local-${{ env.PY }}|${{ hashFiles('pyproject.toml') }}|${{
+            hashFiles('poetry.lock') }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - run: git config --global user.name copier-ci
       - run: git config --global user.email copier@copier
       - run: python -m pip install poetry poetry-dynamic-versioning
@@ -56,12 +61,15 @@ jobs:
           python-version: 3.8
       - run: python -m pip install poetry poetry-dynamic-versioning
       - name: generate cache key PY
-        run: echo "::set-env name=PY::$((python -VV; pip freeze) | sha256sum | cut -d' '
+        run:
+          echo "::set-env name=PY::$((python -VV; pip freeze) | sha256sum | cut -d' '
           -f1)"
       - uses: actions/cache@v1
         with:
           path: ~/.cache
-          key: ${{ env.PY }}|${{ hashFiles('pyproject.toml') }}|${{ hashFiles('poetry.lock') }}|${{ hashFiles('.pre-commit-config.yaml') }}
+          key:
+            ${{ env.PY }}|${{ hashFiles('pyproject.toml') }}|${{
+            hashFiles('poetry.lock') }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - run: poetry install
       - name: Build dist
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,12 +17,15 @@ jobs:
           python-version: 3.8
       - run: python -m pip install poetry poetry-dynamic-versioning
       - name: generate cache key PY
-        run: echo "::set-env name=PY::$((python -VV; pip freeze) | sha256sum | cut -d' '
+        run:
+          echo "::set-env name=PY::$((python -VV; pip freeze) | sha256sum | cut -d' '
           -f1)"
       - uses: actions/cache@v1
         with:
           path: ~/.cache
-          key: ${{ env.PY }}|${{ hashFiles('pyproject.toml') }}|${{ hashFiles('poetry.lock') }}|${{ hashFiles('.pre-commit-config.yaml') }}
+          key:
+            ${{ env.PY }}|${{ hashFiles('pyproject.toml') }}|${{
+            hashFiles('poetry.lock') }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - run: git config --global user.name copier-ci
       - run: git config --global user.email copier@copier
       - run: poetry install

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -2,3 +2,4 @@
 bracketSpacing: false
 endOfLine: lf
 printWidth: 88
+proseWrap: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+All notable changes to this project will be documented in this file. This project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Version 3.0.0 (2020-03)
 
-This is a big release with many new features added and improved.
-The code base also received a lot of love and hardening.
+This is a big release with many new features added and improved. The code base also
+received a lot of love and hardening.
 
 #### Features:
 
@@ -14,11 +14,13 @@ The code base also received a lot of love and hardening.
 - Dropped support for deprecated `voodoo.json`.
 - Introduced gitignore-style patterns for `exclude` und `skip-if-exists`.
 - Dropped support for `include` option.
-- Added support for extending content of config files via content of other files via `pyaml-include`.
+- Added support for extending content of config files via content of other files via
+  `pyaml-include`.
 - Customizable template extension.
 - Ability to remember last answers.
 - Ability to choose where to remember them.
-- Template upgrades support, (based on the previous points) with migration tasks specification.
+- Template upgrades support, (based on the previous points) with migration tasks
+  specification.
 - Extended questions format, supporting help, format, choices and secrets.
 - More beautiful prompts.
 - New CLI experience.
@@ -41,21 +43,24 @@ The code base also received a lot of love and hardening.
 - Improve the output when running tasks.
 - Remove the destination folder if the copy process or one of the tasks fail.
 - Add a `cleanup_on_error` flag to optionally disable the cleanup feature.
-- Add the `skip_if_exists` option to skip files, without asking, if they already exists in the destination folder.
+- Add the `skip_if_exists` option to skip files, without asking, if they already exists
+  in the destination folder.
 
 ### Version 2.4.2 (2019-06)
 
 - Fix MAJOR bug that was preventing the `_exclude`, `_include` and `_tasks` keys from
-  `copier.yml` (or alternatives) to be used at all. It also interpreted `_tasks` as
-  a user-provided variable.
+  `copier.yml` (or alternatives) to be used at all. It also interpreted `_tasks` as a
+  user-provided variable.
 
 ### Version 2.4 (2019-06)
 
 - Empty folders are now copied. The folders are also displayed in the console output
   instead of just the files.
-- `prompt_bool` can now have an undefined default (ans answer is mandatory in that case).
+- `prompt_bool` can now have an undefined default (ans answer is mandatory in that
+  case).
 - Reactivates the `copier.yml` and `copier.yaml` as configuration files.
-- The new `extra_paths` argument specifies additional paths to find templates to inherit from.
+- The new `extra_paths` argument specifies additional paths to find templates to inherit
+  from.
 
 ### Version 2.3 (2019-04)
 
@@ -69,17 +74,17 @@ The code base also received a lot of love and hardening.
 ### Version 2.1 (2019-02)
 
 - Task runner 🎉.
-- Use `_exclude`, `_include`, and `_tasks` keys in `copier.yml` as the default
-  values for the `.copy()` arguments `exclude`, `include`, and `tasks`.
+- Use `_exclude`, `_include`, and `_tasks` keys in `copier.yml` as the default values
+  for the `.copy()` arguments `exclude`, `include`, and `tasks`.
 
 ### Version 2.0 (2019-02)
 
 - Rebranded from `Voodoo` to `Copier`!
 - Dropped support for Python 2.x, the minimal version is now Python 3.5.
 - Cleanup and 100% test coverage.
-- The recommended configuration file is now `copier.yaml`, but a `copier.json`
-  can be used as well. The old `voodoo.json` is also supported _for now_ but is
-  deprecated and will be removed in version 2.2.
+- The recommended configuration file is now `copier.yaml`, but a `copier.json` can be
+  used as well. The old `voodoo.json` is also supported _for now_ but is deprecated and
+  will be removed in version 2.2.
 - Python package format updated to the latest standard (no `setup.py` 😵).
 - Renamed the `render_skeleton()` function to `copy()`. The function signature remains
   almost the same, the only changes are:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
-Contributions are welcome, and they are greatly appreciated! Every
-little bit helps, and credit will always be given.
+Contributions are welcome, and they are greatly appreciated! Every little bit helps, and
+credit will always be given.
 
 You can contribute in many ways:
 
@@ -12,25 +12,23 @@ Report bugs at <https://github.com/jpscaletti/copier/issues>.
 If you are reporting a bug, please include:
 
 - Your operating system name and version.
-- Any details about your local setup that might be helpful in
-  troubleshooting.
+- Any details about your local setup that might be helpful in troubleshooting.
 - Detailed steps to reproduce the bug.
 
 ### Fix Bugs
 
-Look through the GitHub issues for bugs. Anything tagged with "bug" is
-open to whoever wants to implement it.
+Look through the GitHub issues for bugs. Anything tagged with "bug" is open to whoever
+wants to implement it.
 
 ### Implement Features
 
-Look through the GitHub issues for features. Anything tagged with
-"Feature request" is open to whoever wants to implement it.
+Look through the GitHub issues for features. Anything tagged with "Feature request" is
+open to whoever wants to implement it.
 
 ### Write Documentation
 
-The project could always use more documentation, whether as part of the
-official project docs, or even on the web in blog posts, articles, and
-such.
+The project could always use more documentation, whether as part of the official project
+docs, or even on the web in blog posts, articles, and such.
 
 ### Submit Feedback
 
@@ -41,8 +39,8 @@ If you are proposing a feature:
 
 - Explain in detail how it would work.
 - Keep the scope as narrow as possible, to make it easier to implement.
-- Remember that this is a volunteer-driven project, and that
-  contributions are welcome :)
+- Remember that this is a volunteer-driven project, and that contributions are welcome
+  :)
 
 ## Get Started!
 
@@ -96,8 +94,7 @@ git push origin name-of-your-bugfix-or-feature
 Before you submit a pull request, check that it meets these guidelines:
 
 1.  The pull request has code, it should include tests.
-2.  Run `tox` and make sure that the tests pass for all supported Python
-    versions.
+2.  Run `tox` and make sure that the tests pass for all supported Python versions.
 
 ## Tips
 

--- a/README.md
+++ b/README.md
@@ -309,9 +309,29 @@ This will read all available git tags, will compare them using
 before updating. To update to the latest commit, add `--vcs-ref=HEAD`. You can use any
 other git ref you want.
 
-Copier will do its best to respect the answers you provided when copied for the last
-copy, and the git diff that has evolved since the last copy. If there are conflicts, you
-will probably find diff files around.
+When updating, Copier will do its best to respect your project evolution by using the
+answers you provided when copied last time. However, sometimes it's impossible for
+Copier to know what to do with a diff code hunk. In those cases, you will find `*.rej`
+files that contain the unresolved diffs. _You should review those manually_ before
+committing.
+
+You probably don't want `*.rej` files in your git history, but if you add them to
+`.gitignore`, some important changes could pass unnoticed to you. That's why the
+recommended way to deal with them is to _not_ add them to add a
+[pre-commit](https://pre-commit.com/) (or equivalent) hook that forbids them, just like
+this:
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: local
+    hooks:
+      - id: forbidden-files
+        name: forbidden files
+        entry: found copier update rejection files; review them and remove them
+        language: fail
+        files: "\\.rej$"
+```
 
 ## Patterns syntax
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@
 A library for rendering project templates.
 
 - Works with **local** paths and **git URLs**.
-- Your project can include any file and `Copier` can dynamically replace values in any kind of text file.
-- It generates a beautiful output and takes care of not overwrite existing files unless instructed to do so.
+- Your project can include any file and `Copier` can dynamically replace values in any
+  kind of text file.
+- It generates a beautiful output and takes care of not overwrite existing files unless
+  instructed to do so.
 
 ![Sample output](https://github.com/pykong/copier/raw/master/img/copier-output.png)
 
@@ -49,27 +51,25 @@ The content of the files inside the project template is copied to the destinatio
 without changes, **unless they end with `.tmpl`** (or your chosen `templates_suffix`).
 In that case, the templating engine will be used to render them.
 
-A slightly customized Jinja2 templating is used. The main difference is
-those variables are referenced with `[[ name ]]` instead of
-`{{ name }}` and blocks are `[% if name %]` instead of
-`{% if name %}`. To read more about templating see the [Jinja2
-documentation](https://jinja.palletsprojects.com/).
+A slightly customized Jinja2 templating is used. The main difference is those variables
+are referenced with `[[ name ]]` instead of `{{ name }}` and blocks are `[% if name %]`
+instead of `{% if name %}`. To read more about templating see the
+[Jinja2 documentation](https://jinja.palletsprojects.com/).
 
-If a **YAML** file named `copier.yml` is found in the root of the
-project (alternatively, a YAML file named `copier.yaml`), the user will be
-prompted to fill in or confirm the default values.
+If a **YAML** file named `copier.yml` is found in the root of the project
+(alternatively, a YAML file named `copier.yaml`), the user will be prompted to fill in
+or confirm the default values.
 
-Use the `data` argument to pass whatever extra context you want to be available
-in the templates. The arguments can be any valid Python value, even a
-function.
+Use the `data` argument to pass whatever extra context you want to be available in the
+templates. The arguments can be any valid Python value, even a function.
 
-Since version 3.0, only Python 3.6 or later are supported. Please use the
-2.5.1 version if your project runs on a previous Python version.
+Since version 3.0, only Python 3.6 or later are supported. Please use the 2.5.1 version
+if your project runs on a previous Python version.
 
 ## The `copier.yml` file
 
-If a `copier.yml`, or `copier.yaml` is found in the root of the template,
-it will be read and used for two purposes:
+If a `copier.yml`, or `copier.yaml` is found in the root of the template, it will be
+read and used for two purposes:
 
 ### Prompt the user for information
 
@@ -97,18 +97,17 @@ will result in this series of questions:
 
 #### Advanced prompt formatting
 
-Apart from the simplified format, as seen above, Copier supports a more advanced
-format to ask users for data. To use it, the value must be a dict.
+Apart from the simplified format, as seen above, Copier supports a more advanced format
+to ask users for data. To use it, the value must be a dict.
 
 Supported keys:
 
-- **type**: User input must match this type.
-  Options are: bool, float, int, json, str, yaml.
+- **type**: User input must match this type. Options are: bool, float, int, json, str,
+  yaml.
 - **help**: Additional text to help the user know what's this question for.
-- **default**: Leave empty to force the user to answer. Provide a default to
-  save him from typing it if it's quite common. When using **choices**, the
-  default must be the choice _value_, not its _key_. If values are quite long,
-  you can use
+- **default**: Leave empty to force the user to answer. Provide a default to save him
+  from typing it if it's quite common. When using **choices**, the default must be the
+  choice _value_, not its _key_. If values are quite long, you can use
   [YAML anchors](https://confluence.atlassian.com/bitbucket/yaml-anchors-960154027.html).
 
 ```yaml
@@ -174,9 +173,9 @@ close_to_work:
 
 ### Arguments defaults
 
-The keys `_exclude`, `_skip_if_exists`, `_tasks`, and `_extra_paths`
-in the `copier.yml` file, will be treated as the default values for the `exclude`,
-`tasks`, and , `extra_paths` arguments to `copier.copy()`.
+The keys `_exclude`, `_skip_if_exists`, `_tasks`, and `_extra_paths` in the `copier.yml`
+file, will be treated as the default values for the `exclude`, `tasks`, and ,
+`extra_paths` arguments to `copier.copy()`.
 
 Note that they become just _the defaults_, so any explicitly-passed argument will
 overwrite them.
@@ -235,7 +234,10 @@ _extra_paths:
 
 ### Include other yaml files
 
-To reuse configurations across templates you can reference other yaml files. You just need to state the `!include` together with the absolute or relative path to the file to be included. Multiple files can be included per `copier.yml`. For more detailed instructions, see [pyyaml-include](https://github.com/tanbro/pyyaml-include#usage).
+To reuse configurations across templates you can reference other yaml files. You just
+need to state the `!include` together with the absolute or relative path to the file to
+be included. Multiple files can be included per `copier.yml`. For more detailed
+instructions, see [pyyaml-include](https://github.com/tanbro/pyyaml-include#usage).
 
 ```yaml
 # other_place/include_me.yml
@@ -245,20 +247,20 @@ common_setting: "1"
 !include other_place/include_me.yml
 ```
 
-**Warning:** Use only trusted project templates as these tasks run with the
-same level of access as your user.
+**Warning:** Use only trusted project templates as these tasks run with the same level
+of access as your user.
 
 ## The answers file
 
-If the destination path exists and a `.copier-answers.yml` file is
-present there, it will be used to load the last user's answers to the questions
-made in [the `copier.yml` file](#the-copieryml-file).
+If the destination path exists and a `.copier-answers.yml` file is present there, it
+will be used to load the last user's answers to the questions made in
+[the `copier.yml` file](#the-copieryml-file).
 
-This makes projects easier to update because when the user is asked, the default
-answers will be the last ones he used.
+This makes projects easier to update because when the user is asked, the default answers
+will be the last ones he used.
 
-To make sure projects based on your templates can make use of this nice feature,
-**add a file called `[[ _copier_conf.answers_file ]].tmpl`** (or your chosen `templates_suffix`)
+To make sure projects based on your templates can make use of this nice feature, **add a
+file called `[[ _copier_conf.answers_file ]].tmpl`** (or your chosen `templates_suffix`)
 in your template's root folder, with this content:
 
 ```yml
@@ -266,17 +268,20 @@ in your template's root folder, with this content:
 [[_copier_answers|to_nice_yaml]]
 ```
 
-If this file is called different than `[[ _copier_conf.answers_file ]].tmpl` your users will not be able to choose a custom answers file name, and thus they will not be able to integrate several updatable templates into one destination directory.
+If this file is called different than `[[ _copier_conf.answers_file ]].tmpl` your users
+will not be able to choose a custom answers file name, and thus they will not be able to
+integrate several updatable templates into one destination directory.
 
 The builtin `_copier_answers` variable includes all data needed to smooth future updates
-of this project. This includes (but is not limited to) all JSON-serializable
-values declared as user questions in [the `copier.yml` file](#the-copieryml-file).
+of this project. This includes (but is not limited to) all JSON-serializable values
+declared as user questions in [the `copier.yml` file](#the-copieryml-file).
 
-As you can see, you also have the power to customize what will be logged here.
-Keys that start with an underscore (`_`) are specific to Copier. Other keys
-should match questions in `copier.yml`.
+As you can see, you also have the power to customize what will be logged here. Keys that
+start with an underscore (`_`) are specific to Copier. Other keys should match questions
+in `copier.yml`.
 
-If you plan to integrate several templates into one single downstream project, you can use a different path for this file:
+If you plan to integrate several templates into one single downstream project, you can
+use a different path for this file:
 
 ```yaml
 # In your `copier.yml`:
@@ -285,32 +290,40 @@ _answers_file: .my-custom-answers.yml
 
 ### Updating a project
 
-The best way to update a project from its template is when all of these conditions are true:
+The best way to update a project from its template is when all of these conditions are
+true:
 
 1. The template includes a valid `.copier-answers.yml` file.
 2. The template is versioned with git (with tags).
 3. The destination folder is versioned with git.
 
-If that's your case, then just enter the destination folder, make sure
-`git status` shows it clean, and run:
+If that's your case, then just enter the destination folder, make sure `git status`
+shows it clean, and run:
 
 ```bash
 copier update
 ```
 
-This will read all available git tags, will compare them using [PEP 440](https://www.python.org/dev/peps/pep-0440/), and will check out the latest one before updating. To update to the latest commit, add `--vcs-ref=HEAD`. You can use any other git ref you want.
+This will read all available git tags, will compare them using
+[PEP 440](https://www.python.org/dev/peps/pep-0440/), and will check out the latest one
+before updating. To update to the latest commit, add `--vcs-ref=HEAD`. You can use any
+other git ref you want.
 
 Copier will do its best to respect the answers you provided when copied for the last
-copy, and the git diff that has evolved since the last copy. If there are conflicts,
-you will probably find diff files around.
+copy, and the git diff that has evolved since the last copy. If there are conflicts, you
+will probably find diff files around.
 
 ## Patterns syntax
 
-Copier supports matching names against patterns in a gitignore style fashion. This works for the options `exclude` and `skip` . This means you can write patterns as you would for any `.gitignore` file. The full range of the gitignore syntax ist supported via [pathspec]([https://github.com/cpburnz/python-path-specification](https://github.com/cpburnz/python-path-specification).
+Copier supports matching names against patterns in a gitignore style fashion. This works
+for the options `exclude` and `skip` . This means you can write patterns as you would
+for any `.gitignore` file. The full range of the gitignore syntax ist supported via
+[pathspec]([https://github.com/cpburnz/python-path-specification](https://github.com/cpburnz/python-path-specification).
 
 ### Examples for pattern matching
 
-Putting the following settings in your `copier.yaml` file would exclude all files ending with "txt" from being copied to the destination folder, except the file `a.txt`.
+Putting the following settings in your `copier.yaml` file would exclude all files ending
+with "txt" from being copied to the destination folder, except the file `a.txt`.
 
 ```yaml
 _exclude:
@@ -322,19 +335,23 @@ _exclude:
 
 ## Template helpers
 
-In addition to [all the features Jinja supports](https://jinja.palletsprojects.com/en/2.10.x/templates/),
+In addition to
+[all the features Jinja supports](https://jinja.palletsprojects.com/en/2.10.x/templates/),
 Copier includes:
 
 ### Builtin variables/functions
 
 - `now()` to get current UTC time.
 - `make_secret()` to get a random string.
-- `_copier_answers` includes the current answers dict, but slightly modified to make it suitable to [autoupdate your project safely](#the-answers-file):
+- `_copier_answers` includes the current answers dict, but slightly modified to make it
+  suitable to [autoupdate your project safely](#the-answers-file):
   - It doesn't contain secret answers.
   - It doesn't contain any data that is not easy to render to JSON or YAML.
-- `_copier_conf` includes the current copier `ConfigData` object, also slightly modified:
+- `_copier_conf` includes the current copier `ConfigData` object, also slightly
+  modified:
   - It only contains JSON-serializable data.
-  - But you have to serialize it with `[[ _copier_conf.json() ]]` instead of `[[ _copier_conf|tojson ]]`.
+  - But you have to serialize it with `[[ _copier_conf.json() ]]` instead of
+    `[[ _copier_conf|tojson ]]`.
   - ⚠️ It contains secret answers inside its `.data` key.
   - Modifying it doesn't alter the current rendering configuration.
 
@@ -343,8 +360,8 @@ Copier includes:
 - `anything|to_nice_yaml` to print as pretty-formatted YAML.
 
   Without arguments it defaults to:
-  `anything|to_nice_yaml(indent=2, width=80, allow_unicode=True)`,
-  but you can modify those.
+  `anything|to_nice_yaml(indent=2, width=80, allow_unicode=True)`, but you can modify
+  those.
 
 ---
 
@@ -378,33 +395,29 @@ Uses the template in _src_path_ to generate a new project at _dst_path_.
 
 **Arguments**:
 
-- **src_path** (str):<br>
-  Absolute path to the project skeleton, which can also be a version control
-  system URL.
+- **src_path** (str):<br> Absolute path to the project skeleton, which can also be a
+  version control system URL.
 
-- **dst_path** (str):<br>
-  Absolute path to where to render the skeleton.
+- **dst_path** (str):<br> Absolute path to where to render the skeleton.
 
-- **data** (dict):<br>
-  Data to be passed to the templates in addition to the user data from
-  a `copier.yml`.
+- **data** (dict):<br> Data to be passed to the templates in addition to the user data
+  from a `copier.yml`.
 
-- **exclude** (list):<br>
-  A list of names or gitignore-style patterns matching files or folders
-  that must not be copied.
+- **exclude** (list):<br> A list of names or gitignore-style patterns matching files or
+  folders that must not be copied.
 
-- **skip_if_exists** (list):<br>
-  A list of names or gitignore-style patterns matching files or folders, that are skipped if another with the same name already exists in the destination folder. (It only makes sense if you are copying to a folder that already exists).
+- **skip_if_exists** (list):<br> A list of names or gitignore-style patterns matching
+  files or folders, that are skipped if another with the same name already exists in the
+  destination folder. (It only makes sense if you are copying to a folder that already
+  exists).
 
-- **tasks** (list):<br>
-  Optional lists of commands to run in order after finishing the copy. Like in
-  the templates files, you can use variables on the commands that will be
-  replaced by the real values before running the command. If one of the commands
-  fails, the rest of them will not run.
+- **tasks** (list):<br> Optional lists of commands to run in order after finishing the
+  copy. Like in the templates files, you can use variables on the commands that will be
+  replaced by the real values before running the command. If one of the commands fails,
+  the rest of them will not run.
 
-- **envops** (dict):<br>
-  Extra options for the Jinja template environment.
-  See available options in
+- **envops** (dict):<br> Extra options for the Jinja template environment. See available
+  options in
   [Jinja's docs](https://jinja.palletsprojects.com/en/2.10.x/api/#jinja2.Environment).
 
   Copier uses these defaults that are different from Jinja's:
@@ -435,29 +448,26 @@ Uses the template in _src_path_ to generate a new project at _dst_path_.
     keep_trailing_newline: false
   ```
 
-- **extra_paths** (list):<br>
-  Additional paths, from where to search for templates. This is intended to be
-  used with shared parent templates, files with macros, etc. outside the copied
-  project skeleton.
+- **extra_paths** (list):<br> Additional paths, from where to search for templates. This
+  is intended to be used with shared parent templates, files with macros, etc. outside
+  the copied project skeleton.
 
-- **pretend** (bool):<br>
-  Run but do not make any changes.
+- **pretend** (bool):<br> Run but do not make any changes.
 
-- **force** (bool):<br>
-  Overwrite files that already exist, without asking.
+- **force** (bool):<br> Overwrite files that already exist, without asking.
 
-- **skip** (bool):<br>
-  Skip files that already exist, without asking.
+- **skip** (bool):<br> Skip files that already exist, without asking.
 
-- **quiet** (bool):<br>
-  Suppress the status output.
+- **quiet** (bool):<br> Suppress the status output.
 
-- **cleanup_on_error** (bool):<br>
-  Remove the destination folder if the copy process or one of the tasks fails.
-  True by default.
+- **cleanup_on_error** (bool):<br> Remove the destination folder if the copy process or
+  one of the tasks fails. True by default.
 
 ## Credits
 
-Special thanks go to [jpscaletti](<[https://github.com/jpscaletti](https://github.com/jpscaletti)>) for originally creating `Copier`. This project would not be a thing without him.
+Special thanks go to
+[jpscaletti](<[https://github.com/jpscaletti](https://github.com/jpscaletti)>) for
+originally creating `Copier`. This project would not be a thing without him.
 
-Big thanks also go to [Yajo](<[https://github.com/Yajo](https://github.com/Yajo)>) for his relentless zest for improving `Copier` even further.
+Big thanks also go to [Yajo](<[https://github.com/Yajo](https://github.com/Yajo)>) for
+his relentless zest for improving `Copier` even further.


### PR DESCRIPTION
 Add `proseWrap: always` to prettier configuration, and re-run pre-commit

This makes YAML and MD files to be automatically wrapped when possible and when it doesn't alter the content meaning. All looks better this way.

Be more specific about what those `*.rej` files are and what to do with them.

