### PR TITLE
Move pytest-xdist as development dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ pyyaml = "^5.3"
 pyyaml-include = "^1.2"
 # packaging is needed when installing from PyPI
 packaging = "^20.1"
-pytest-xdist = "^1.31.0"
 
 [tool.poetry.dev-dependencies]
 black = {version = "^19.10b0", allow-prereleases = true}
@@ -52,6 +51,7 @@ packaging = "*"
 pre-commit = "*"
 pytest = "^5.3"
 pytest-cov = "*"
+pytest-xdist = "^1.31.0"
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
Just noticed that pytest-xdist was listed in the "production" dependency, which seems wrong.