### PR TITLE
Fix path to jinja get_template on Windows

### DIFF
--- a/copier/tools.py
+++ b/copier/tools.py
@@ -155,6 +155,7 @@ class Renderer:
         relpath = (
             str(fullpath).replace(str(self.conf.src_path), "", 1).lstrip(os.path.sep)
         )
+        relpath = relpath.replace("\\", "/")
         tmpl = self.env.get_template(relpath)
         return tmpl.render(**self.data)
 


### PR DESCRIPTION
With a jinja Environment get_template call, the path must always be given with forward slashes (see https://github.com/pallets/jinja/issues/767). On windows, in `Renderer.__call__`, relpath is returning with backslashes, so I added a replace statement to switch them in this case.